### PR TITLE
Emit Java 11 bytecode so JDK 11+ consumers can use the library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,13 +8,23 @@ plugins {
     alias(libs.plugins.gradleup.nmcp.aggregation)
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-}
-
 kotlin {
     jvmToolchain(21)
+}
+
+// Emit Java 11 bytecode for the published jar so consumers on JDK 11+ can use the
+// library (https://github.com/compscidr/logips/issues/83). -Xjdk-release links against
+// the JDK 11 API surface so use of newer APIs fails our build instead of consumers'.
+// Tests still compile and run on the JDK 21 toolchain.
+tasks.compileJava {
+    options.release = 11
+}
+
+tasks.compileKotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+        freeCompilerArgs.add("-Xjdk-release=11")
+    }
 }
 
 tasks.jacocoTestReport {


### PR DESCRIPTION
Fixes #83

Since the bump to JDK 21, the published jar contained Java 21 bytecode and its Gradle module metadata declared `org.gradle.jvm.version: 21`, so consumers targeting older JDKs (e.g. 17) failed to resolve or load the library.

`LogIp.kt` uses no JDK-21-specific APIs — only `java.net.NetworkInterface` and the SLF4J 2.x fluent API — so rather than a multi-release jar (which is for shipping different code per JDK), this lowers the bytecode target of the published classes to Java 11:

- The main compilation now uses `jvmTarget = JVM_11` with `-Xjdk-release=11`, so the compiler also links against the JDK 11 API surface: any future use of a newer API fails this repo's build instead of crashing consumers at runtime.
- `compileJava` gets `options.release = 11` so the published Gradle metadata declares JVM version 11.
- The build and tests still use the JDK 21 toolchain (test compilation stays at 21, which JUnit 6 requires).

Verified locally:
- `./gradlew build` passes (tests + lint).
- `javap -verbose` on `LogIp.class` from the built jar shows class file major version 55 (Java 11).
- The generated module metadata declares `org.gradle.jvm.version: 11` for both api and runtime variants.

Consumers on JDK 11 through the latest releases can now use the library; only sub-11 JDKs remain unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)